### PR TITLE
[IS-1265] close earlgrey(RabbitMQ) connection supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - rabbitmq-server
 
 python:
+  - "3.6"
   - "3.7"
 
 branches:

--- a/earlgrey/message_queue_connection.py
+++ b/earlgrey/message_queue_connection.py
@@ -55,6 +55,10 @@ class MessageQueueConnection:
 
         self._async_info = MessageQueueInfoAsync(self._channel, self._route_key)
 
+    async def close(self):
+        if self._connection:
+            await self._connection.close()
+
     def async_info(self):
         return self._async_info
 

--- a/earlgrey/message_queue_info.py
+++ b/earlgrey/message_queue_info.py
@@ -17,17 +17,17 @@ from pika.adapters.blocking_connection import BlockingChannel
 
 
 class MessageQueueInfoAsync:
-    def __init__(self, channel: RobustChannel, route_key: str=None):
+    def __init__(self, channel: RobustChannel, route_key: str = None):
         self._channel = channel
         self._route_key = route_key
 
-    async def queue_info(self, name: str=None):
+    async def queue_info(self, name: str = None):
         if name is None:
             name = self._route_key
 
         return await self._channel.declare_queue(name, passive=True)
 
-    async def exchange_info(self, name: str=None):
+    async def exchange_info(self, name: str = None):
         return await self._channel.declare_exchange(name, passive=True)
 
 
@@ -36,13 +36,13 @@ class MessageQueueInfoSync:
         self._channel = channel
         self._route_key = route_key
 
-    def queue_info(self, name: str=None):
+    def queue_info(self, name: str = None):
         if name is None:
             name = self._route_key
 
         return self._channel.queue_declare(queue=name, passive=True)
 
-    def exchange_info(self, name: str=None):
+    def exchange_info(self, name: str = None):
         if name is None:
             name = self._route_key
 

--- a/earlgrey/message_queue_service.py
+++ b/earlgrey/message_queue_service.py
@@ -49,6 +49,13 @@ class MessageQueueService(MessageQueueConnection, Generic[T]):
 
         await self._serve_tasks()
 
+    async def close(self):
+        if self._rpc_server:
+            await self._rpc_server.close()
+        if self._worker_server:
+            await self._worker_server.close()
+        await super().close()
+
     async def _serve_tasks(self):
         for attribute_name in dir(self._task):
             try:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -57,6 +57,9 @@ class TestBasic(unittest.TestCase):
 
             self.assertEqual(0, len(order))
 
+            await server.close()
+            await client.close()
+
         loop = asyncio.get_event_loop()
         loop.run_until_complete(_run())
 
@@ -103,7 +106,8 @@ class TestBasic(unittest.TestCase):
             info = client.sync_info().queue_info()
             self.assertEqual(info.method.message_count, 0)
 
+            await server.close()
+            await client.close()
+
         loop = asyncio.get_event_loop()
         loop.run_until_complete(_run())
-
-


### PR DESCRIPTION
- added `close` method to disconnect and cleanup resources.
- added `on_return_callback` to notify when published message is rejected and returned by the server 
